### PR TITLE
:bug: Corrigindo execução errada durante PR

### DIFF
--- a/.github/workflows/pages-auto-deploy.yml
+++ b/.github/workflows/pages-auto-deploy.yml
@@ -3,8 +3,6 @@ name: Pages Auto-Deploy
 on:
   push:
     branches: [ "docs" ]
-  pull_request:
-    branches: [ "docs" ]
     
   workflow_dispatch:
 


### PR DESCRIPTION
As linhas removidas nesse commit estavam causando a execução do workflow quando um PR era feito.

Como não está no escopo desse workflow a verificação durante um PR, tais linhas foram removidas.